### PR TITLE
Construction wands + cyclic fixed v1.5.6

### DIFF
--- a/src/defaultconfigs/constructionwand-server.toml
+++ b/src/defaultconfigs/constructionwand-server.toml
@@ -66,5 +66,5 @@
 	TEWhitelist = false
 	#White/Blacklist for Tile Entities. Allow/Prevent blocks with TEs from being placed by wand.
 	#You can either add block ids like minecraft:chest or mod ids like minecraft
-	TEList = ["chiselsandbits", "cyclic:fluid_pipe", "cyclic:item_pipe", "cyclic:energy_pipe"]
+	TEList = ["chiselsandbits"]
 


### PR DESCRIPTION
I fixed the bug so now construction wand and cables play nice together.  
Please consider trying them out and reverting this list

Requires Cyclic 1.16.5 - 1.5.6 or higher
https://www.curseforge.com/minecraft/mc-mods/cyclic/files/3501889